### PR TITLE
Add support for inline captcha display

### DIFF
--- a/aws_google_auth/__init__.py
+++ b/aws_google_auth/__init__.py
@@ -42,6 +42,7 @@ def parse_args(args):
     parser.add_argument('--resolve-aliases', action='store_true', help='Resolve AWS account aliases.')
     parser.add_argument('--save-failure-html', action='store_true', help='Write HTML failure responses to file for troubleshooting.')
     parser.add_argument('--save-saml-flow', action='store_true', help='Write all GET and PUT requests and HTML responses to/from Google to files for troubleshooting.')
+    parser.add_argument('--inline-captcha', action='store_true', help='Display Captcha images inline in terminal. Compatible with iterm2 only. See https://iterm2.com/documentation-images.html for setup.')
 
     role_group = parser.add_mutually_exclusive_group()
     role_group.add_argument('-a', '--ask-role', action='store_true', help='Set true to always pick the role')
@@ -239,7 +240,7 @@ def process_auth(args, config):
         # Validate Options
         config.raise_if_invalid()
 
-        google_client = google.Google(config, save_failure=args.save_failure_html, save_flow=args.save_saml_flow)
+        google_client = google.Google(config, save_failure=args.save_failure_html, save_flow=args.save_saml_flow, inline_captcha=args.inline_captcha)
         google_client.do_login()
         saml_xml = google_client.parse_saml()
         logging.debug('%s: saml assertion is: %s', __name__, saml_xml)

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -18,6 +18,7 @@ from bs4 import BeautifulSoup
 from requests import HTTPError
 from six import print_ as print
 from six.moves import urllib_parse, input
+from imgcat import imgcat
 
 from aws_google_auth import _version
 
@@ -35,7 +36,7 @@ class ExpectedGoogleException(Exception):
 
 
 class Google:
-    def __init__(self, config, save_failure, save_flow=False):
+    def __init__(self, config, save_failure, save_flow=False, inline_captcha=False):
         """The Google object holds authentication state
         for a given session. You need to supply:
 
@@ -53,6 +54,7 @@ class Google:
         self.base_url = 'https://accounts.google.com'
         self.save_failure = save_failure
         self.session_state = None
+        self.inline_captcha = inline_captcha
         self.save_flow = save_flow
         if save_flow:
             self.save_flow_dict = {}
@@ -498,7 +500,10 @@ class Google:
             try:
                 with requests.get(captcha_url) as url:
                     with io.BytesIO(url.content) as f:
-                        Image.open(f).show()
+                        if self.inline_captcha:
+                            imgcat(Image.open(f))
+                        else:
+                            Image.open(f).show()
             except Exception:
                 pass
 

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -18,7 +18,11 @@ from bs4 import BeautifulSoup
 from requests import HTTPError
 from six import print_ as print
 from six.moves import urllib_parse, input
-from imgcat import imgcat
+has_imgcat = True
+try:
+    from imgcat import imgcat
+except ImportError:
+    has_imgcat = False
 
 from aws_google_auth import _version
 

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -504,7 +504,7 @@ class Google:
             try:
                 with requests.get(captcha_url) as url:
                     with io.BytesIO(url.content) as f:
-                        if self.inline_captcha:
+                        if self.inline_captcha and has_imgcat and sys.platform == 'darwin':
                             imgcat(Image.open(f))
                         else:
                             Image.open(f).show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ requests
 six
 tabulate
 tzlocal
-imgcat
+imgcat; sys_platform == 'darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 six
 tabulate
 tzlocal
+imgcat


### PR DESCRIPTION
Add a flag to enable inline captcha image so that this doesn't open an external image app.

The default behavior will keep this command as-is. Adding this flag will display the captcha in your terminal.

**This works for iTerm2 users only!**

Please enable inline images before attempting to use this: https://iterm2.com/documentation-images.html

## Testing:

To test, install from this commit:
```
pip3 install git+https://github.com/aerospike-dbaas/aws-google-auth@9d042d3177c2330d565055b62211671c0fbf71a5
```

### Example Usage:

```
# aws-google-auth -k --bg-response js_enabled --inline-captcha
```

### Example output:

Please visit the following URL to view your CAPTCHA: https://accounts.google.com/Captcha?REDACTED_URL
![iTerm2 EMKJDy](https://github.com/Aerospike-DBaaS/aws-google-auth/assets/29213384/91e75748-d8a7-4db0-bffb-650ed1efb79a)

Captcha (case insensitive): substile
MFA token: XXXXXX